### PR TITLE
feat: add JSON swears list support with auto-detection and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. The user provides a local audio file (or a URL pointing to an audio file which is downloaded)
 2. Either [Whisper](https://openai.com/research/whisper) ([GitHub](https://github.com/openai/whisper)) or the [Vosk](https://alphacephei.com/vosk/)-[API](https://github.com/alphacep/vosk-api) is used to recognize speech in the audio file
-3. Each recognized word is checked against a [list](./src/monkeyplug/swears.txt) of profanity or other words you'd like muted
+3. Each recognized word is checked against a [list](./src/monkeyplug/swears.txt) of profanity or other words you'd like muted (supports text or [JSON format](./SWEARS_JSON_FORMAT.md))
 4. [`ffmpeg`](https://www.ffmpeg.org/) is used to create a cleaned audio file, muting or "bleeping" the objectional words
 
 You can then use your favorite media player to play the cleaned audio file.
@@ -65,7 +65,7 @@ options:
   --output-json <string>
                         Output file to store transcript JSON
   -w <profanity file>, --swears <profanity file>
-                        text file containing profanity (default: "swears.txt")
+                        text or JSON file containing profanity (default: "swears.txt")
   -a <str>, --audio-params <str>
                         Audio parameters for ffmpeg (default depends on output audio codec)
   -c <int>, --channels <int>

--- a/src/monkeyplug/monkeyplug.py
+++ b/src/monkeyplug/monkeyplug.py
@@ -385,12 +385,8 @@ class Plugger(object):
             self.swearsFileSpec = iSwearsFileSpec
         else:
             raise IOError(errno.ENOENT, os.strerror(errno.ENOENT), iSwearsFileSpec)
-        lines = []
-        with open(self.swearsFileSpec) as f:
-            lines = [line.rstrip("\n") for line in f]
-        for line in lines:
-            lineMap = line.split("|")
-            self.swearsMap[scrubword(lineMap[0])] = lineMap[1] if len(lineMap) > 1 else "*****"
+        
+        self._load_swears_file()
 
         if self.debug:
             mmguero.eprint(f'Input: {self.inputFileSpec}')
@@ -414,6 +410,56 @@ class Plugger(object):
         # if we downloaded the input file, remove it as well
         if os.path.isfile(self.tmpDownloadedFileSpec):
             os.remove(self.tmpDownloadedFileSpec)
+
+    ######## _load_swears_file ####################################################
+    def _load_swears_file(self):
+        """Load swears from text or JSON format"""
+        # Try to detect and parse JSON first
+        is_json = False
+        if self.swearsFileSpec.lower().endswith('.json'):
+            is_json = True
+        else:
+            # Try to parse as JSON even without .json extension
+            try:
+                with open(self.swearsFileSpec, 'r') as f:
+                    content = f.read()
+                    json.loads(content)
+                    is_json = True
+            except (json.JSONDecodeError, ValueError):
+                pass
+        
+        if is_json:
+            self._load_swears_from_json()
+        else:
+            self._load_swears_from_text()
+        
+        if self.debug:
+            mmguero.eprint(f'Loaded {len(self.swearsMap)} profanity entries from {self.swearsFileSpec}')
+    
+    def _load_swears_from_json(self):
+        """Load swears from JSON format - simple array of strings
+        
+        Format: ["word1", "word2", "word3", ...]
+        Example: https://github.com/zautumnz/profane-words/blob/master/words.json
+        """
+        with open(self.swearsFileSpec, 'r') as f:
+            data = json.load(f)
+        
+        if not isinstance(data, list):
+            raise ValueError(f"JSON swears file must contain an array of strings, got {type(data).__name__}")
+        
+        for item in data:
+            if isinstance(item, str) and item.strip():
+                self.swearsMap[scrubword(item)] = "*****"
+    
+    def _load_swears_from_text(self):
+        """Load swears from pipe-delimited text format (legacy)"""
+        lines = []
+        with open(self.swearsFileSpec) as f:
+            lines = [line.rstrip("\n") for line in f]
+        for line in lines:
+            lineMap = line.split("|")
+            self.swearsMap[scrubword(lineMap[0])] = lineMap[1] if len(lineMap) > 1 else "*****"
 
     ######## CreateCleanMuteList #################################################
     def CreateCleanMuteList(self):

--- a/tests/test_swears_loading.py
+++ b/tests/test_swears_loading.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import tempfile
+import pytest
+from monkeyplug.monkeyplug import Plugger, scrubword
+
+
+class MockPlugger:
+    """Minimal mock Plugger for testing swears loading without audio file requirements"""
+    def __init__(self, swearsFileSpec, debug=False):
+        self.swearsFileSpec = swearsFileSpec
+        self.swearsMap = {}
+        self.debug = debug
+        
+        # Import the methods we need to test
+        self._load_swears_file = Plugger._load_swears_file.__get__(self)
+        self._load_swears_from_json = Plugger._load_swears_from_json.__get__(self)
+        self._load_swears_from_text = Plugger._load_swears_from_text.__get__(self)
+
+
+class TestSwearsLoading:
+    """Test suite for swears list loading (JSON and text formats)"""
+
+    def test_load_json_swears_from_file(self):
+        """Test loading swears from JSON format file"""
+        # Create a temporary JSON swears file
+        test_swears = ["damn", "hell", "crap", "badword"]
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(test_swears, f)
+            temp_json_file = f.name
+        
+        try:
+            # Create mock plugger to test swears loading
+            plugger = MockPlugger(temp_json_file)
+            plugger._load_swears_file()
+            
+            # Verify swears were loaded correctly
+            assert len(plugger.swearsMap) == len(test_swears)
+            
+            # Verify each word is in the map
+            for word in test_swears:
+                assert scrubword(word) in plugger.swearsMap
+                assert plugger.swearsMap[scrubword(word)] == "*****"
+            
+        finally:
+            if os.path.exists(temp_json_file):
+                os.unlink(temp_json_file)
+
+    def test_load_text_swears_from_file(self):
+        """Test loading swears from legacy text format (backward compatibility)"""
+        # Create a temporary text swears file
+        test_swears = [
+            "damn|dang",
+            "hell",
+            "crap|crud",
+        ]
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write('\n'.join(test_swears))
+            temp_text_file = f.name
+        
+        try:
+            plugger = MockPlugger(temp_text_file)
+            plugger._load_swears_file()
+            
+            # Verify swears were loaded correctly
+            assert len(plugger.swearsMap) == 3
+            
+            # Verify words are mapped correctly
+            assert scrubword("damn") in plugger.swearsMap
+            assert plugger.swearsMap[scrubword("damn")] == "dang"
+            
+            assert scrubword("hell") in plugger.swearsMap
+            assert plugger.swearsMap[scrubword("hell")] == "*****"
+            
+            assert scrubword("crap") in plugger.swearsMap
+            assert plugger.swearsMap[scrubword("crap")] == "crud"
+            
+        finally:
+            if os.path.exists(temp_text_file):
+                os.unlink(temp_text_file)
+
+    def test_json_format_auto_detection_by_extension(self):
+        """Test that JSON format is auto-detected by .json extension"""
+        test_swears = ["test1", "test2", "test3"]
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(test_swears, f)
+            temp_json_file = f.name
+        
+        try:
+            plugger = MockPlugger(temp_json_file)
+            plugger._load_swears_file()
+            
+            assert len(plugger.swearsMap) == 3
+            
+        finally:
+            if os.path.exists(temp_json_file):
+                os.unlink(temp_json_file)
+
+    def test_json_and_text_produce_same_results(self):
+        """Test that the same words in JSON and text format produce identical swearsMap"""
+        # Define the same set of words
+        test_words = ["damn", "hell", "crap", "badword"]
+        
+        # Create JSON version
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(test_words, f)
+            temp_json_file = f.name
+        
+        # Create text version (simple format without replacements)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write('\n'.join(test_words))
+            temp_text_file = f.name
+        
+        try:
+            # Load JSON format
+            plugger_json = MockPlugger(temp_json_file)
+            plugger_json._load_swears_file()
+            
+            # Load text format
+            plugger_text = MockPlugger(temp_text_file)
+            plugger_text._load_swears_file()
+            
+            # Both should have the same number of entries
+            assert len(plugger_json.swearsMap) == len(plugger_text.swearsMap)
+            assert len(plugger_json.swearsMap) == len(test_words)
+            
+            # Both should have identical keys (normalized words)
+            assert set(plugger_json.swearsMap.keys()) == set(plugger_text.swearsMap.keys())
+            
+            # Verify each word is present and normalized the same way
+            for word in test_words:
+                normalized = scrubword(word)
+                assert normalized in plugger_json.swearsMap
+                assert normalized in plugger_text.swearsMap
+                # Both should map to the default replacement
+                assert plugger_json.swearsMap[normalized] == "*****"
+                assert plugger_text.swearsMap[normalized] == "*****"
+            
+        finally:
+            if os.path.exists(temp_json_file):
+                os.unlink(temp_json_file)
+            if os.path.exists(temp_text_file):
+                os.unlink(temp_text_file)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This PR simply adds support for json lists to take advantage of some community maintained swear lists in JSON format. Some simple tests are included